### PR TITLE
[Feat] Add product listing and payment gateway selection on index page

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,11 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!
+  def index
+    products = Product.all
+    @products_purchase = products.where(stripe_plan_name: nil, paypal_plan_name: nil)
+    @products_subscription = products - @products_purchase
+  end
+
+  def submit
+  end
+end

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -1,0 +1,59 @@
+%div
+  %h1 List of products
+  = form_tag({:controller => "orders", :action => "submit" }, {:id => 'order-details'}) do
+    %input{id:'order-type', :type=>"hidden", :value=>"stripe", :name=>'orders[payment_gateway]'}
+    .form_row
+      %h4 Charges/Payments
+      - @products_purchase.each do |product|
+        %div{'data-charges-and-payments-section': true}
+          = radio_button_tag 'orders[product_id]', product.id, @products_purchase.first == product
+          %span{id: "radioButtonName#{product.id}"} #{product.name}
+          %span{id: "radioButtonPrice#{product.id}", :'data-price' => "#{product.price_cents}"} #{humanized_money_with_symbol product.price}
+        %br
+      %h4 Subscriptions
+      - @products_subscription.each do |product|
+        %div
+          = radio_button_tag 'orders[product_id]', product.id, false
+          %span{id: "radioButtonName#{product.id}"} #{product.name}
+          %span{id: "radioButtonPrice#{product.id}", :'data-price' => "#{product.price_cents}"} #{humanized_money_with_symbol product.price}
+        %br
+    %hr
+    %h1 Payment Method
+    .form_row
+      %div
+        = radio_button_tag 'payment-selection', 'stripe', true, onclick: "changeTab();"
+        %span Stripe
+      %br
+      %div
+        = radio_button_tag 'payment-selection', 'paypal', false, onclick: "changeTab();"
+        %span Paypal
+    %br
+    %br
+    %div{id:'tab-stripe', class:'paymentSelectionTab active'}
+      %div{id:'card-element'}
+      %div{id:'card-errors', role:"alert"}
+      %br
+      %br
+      = submit_tag "Buy it!", id: "submit-stripe"
+    %div{id:'tab-paypal', class:'paymentSelectionTab'}
+      %div{id: "submit-paypal"}
+    %br
+    %br
+    %hr
+:javascript
+  function changeTab() {
+    var newActiveTabID = $('input[name="payment-selection"]:checked').val();
+    $('.paymentSelectionTab').removeClass('active');
+    $('#tab-' + newActiveTabID).addClass('active');
+  }
+
+:css
+  #card-element {
+    width:500px;
+  }
+  .paymentSelectionTab {
+    display: none;
+  }
+  .paymentSelectionTab.active {
+    display: block !important;
+  }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  get "/", to: "orders#index"
+  post "/orders/submit", to: "orders#submit"
 end


### PR DESCRIPTION
## Description
This MR adds the product listing and payment gateway selection functionality to the index page. It includes:
- Routes for the `index` and `submit` actions.
- `OrdersController` with `index` and `submit` actions.
- `index.html.haml` view for displaying products and payment options.
- Basic front-end logic for switching between Stripe and PayPal.

## Changes
- **Routes**: Added `get '/'` and `post '/orders/submit'` in `config/routes.rb`.
- **Controller**: Implemented `index` and `submit` actions in `OrdersController`.
- **View**: Created `index.html.haml` with product listing and payment gateway selection.
- **Front-end**: Added JavaScript and CSS for payment method tab switching.