### PR TITLE
[Feat] Integrate Stripe payment gateway and secure credential storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,10 @@ pickle-email-*.html
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/master.key
+/config/application.yml
 
 # Only include if you have production secrets in this file, which is no longer a Rails default
-# config/secrets.yml
+config/secrets.yml
 
 # dotenv, dotenv-rails
 # TODO Comment out these rules if environment variables can be committed

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "puma", ">= 5.0"
 gem "rails", "~> 7.2.2", ">= 7.2.2.1"
 gem "sprockets-rails"
 gem "stimulus-rails"
+gem "stripe-rails", "~> 2.6"
 gem "turbo-rails"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,11 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.2)
+    stripe (13.3.1)
+    stripe-rails (2.6.0)
+      rails (>= 5.1)
+      responders
+      stripe (>= 3.15.0)
     temple (0.10.3)
     thor (1.3.2)
     tilt (2.6.0)
@@ -361,6 +366,7 @@ DEPENDENCIES
   selenium-webdriver
   sprockets-rails
   stimulus-rails
+  stripe-rails (~> 2.6)
   turbo-rails
   tzinfo-data
   web-console

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -1,3 +1,4 @@
+= stripe_javascript_tag
 %div
   %h1 List of products
   = form_tag({:controller => "orders", :action => "submit" }, {:id => 'order-details'}) do
@@ -40,7 +41,47 @@
     %br
     %br
     %hr
+
 :javascript
+  (function setupStripe() {
+    // Initialize stripe with publishable key
+    var stripe = Stripe("#{ENV['STRIPE_PUBLISHABLE_KEY']}");
+
+    // Create Stripe credit card elements
+    var elements = stripe.elements();
+    var card = elements.create('card');
+
+    // Add a listener to check for errors
+    card.addEventListener('change', function(event) {
+      var displayError = document.getElementById('card-errors');
+      document.getElementById('submit-stripe').disabled = false;
+      if (event.error) {
+        displayError.textContent = event.error.message;
+      } else {
+        displayError.textContent = '';
+      }
+    });
+
+    // Mount Stripe card element
+    card.mount('#card-element');
+    var form = document.getElementById('order-details');
+    form.addEventListener('submit', function(event) {
+      $('#submit-stripe').prop('disabled', true);
+      event.preventDefault();
+      stripe.createToken(card).then(function(result) {
+        if (result.error) {
+          var errorElement = document.getElementById('card-errors');
+          errorElement.textContent = result.error.message;
+        } else {
+          var $form = $("#order-details");
+          $form.append($('<input type="hidden" name="orders[token]"/>').val(result.token.id));
+          $('#order-type').val('stripe');
+          $form.submit();
+        }
+      });
+      return false;
+    });
+  }());
   function changeTab() {
     var newActiveTabID = $('input[name="payment-selection"]:checked').val();
     $('.paymentSelectionTab').removeClass('active');
@@ -49,7 +90,7 @@
 
 :css
   #card-element {
-    width:500px;
+    width: 500px;
   }
   .paymentSelectionTab {
     display: none;

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,10 @@ module PaymentDemo
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    # Load application.yml and set environment variables
+    config_file = Rails.application.config_for(:application)
+    config_file.each do |key, value|
+      ENV[key.to_s] = value.to_s
+    end unless config_file.nil?
   end
 end

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  config.stripe.secret_key = ENV["STRIPE_SECRET_KEY"]
+  config.stripe.publishable_key = ENV["STRIPE_PUBLISHABLE_KEY"]
+end


### PR DESCRIPTION
## Description
This MR integrates the Stripe payment gateway into the application. It includes secure storage of payment gateway credentials, Stripe API initialization, and front-end integration for secure credit card input fields.

## Changes
- Added `stripe-rails` gem to the Gemfile
- Created `config/application.yml` for storing PayPal and Stripe credentials (ignored by Git)
- Initialized Stripe module in `config/initializers/stripe.rb`
- Integrated Stripe.js in `index.html.haml` for secure credit card input fields
- Added JavaScript logic for token generation and form submission
- Updated `.gitignore` to exclude `config/application.yml`.